### PR TITLE
added onHover for CellPlot and Rectangle components

### DIFF
--- a/src/CellPlot.tsx
+++ b/src/CellPlot.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import Frame from './Frame';
-import Cells from './Cells';
+import Cells, {Coordinate} from './Cells';
 import {PlotContext, PlotContextProps} from './PlotContext';
 import {PlotConsumer, PlotConsumerProps} from './PlotConsumer';
 
@@ -14,7 +14,8 @@ export interface Props {
   horizontalBorders?: string[]; // a cyclic sequence of strings for the css border property
   ys: number[];
 
-  onClick?: (x: number, y: number) => void;
+  onClick?: (x: number, y: number) => void; // TODO: convert to Coordinate in 2.x release
+  onHover?: (coordinate: Coordinate) => void;
 }
 
 function snap(value: number, interval: number): number {
@@ -92,7 +93,8 @@ export default class CellPlot extends React.Component<Props> {
           verticalBorders={this.props.verticalBorders}
           ys={this.props.ys}
           horizontalBorders={this.props.horizontalBorders}
-          onClick={this.props.onClick} />
+          onClick={this.props.onClick}
+          onHover={this.props.onHover} />
 
         {this.props.children}
       </Frame>

--- a/src/Cells.tsx
+++ b/src/Cells.tsx
@@ -1,12 +1,18 @@
 import * as React from 'react';
 import styled from 'styled-components';
 
+export interface Coordinate {
+  x: number;
+  y: number;
+}
+
 export interface Props {
   xs: any[];
   ys: any[];
   verticalBorders?: string[];
   horizontalBorders?: string[];
   onClick?: (x: any, y: any) => void;
+  onHover?: (coordinate: Coordinate | null) => void;
 }
 
 const Columns = styled.div`
@@ -31,7 +37,7 @@ const Cell = styled.div`
  * Cells can be placed inside a Frame to create vertical and horizontal gridlines. It acts as a
  * background layer, and does not render children.
  */
-const Cells: React.SFC<Props> = ({xs, ys, verticalBorders, horizontalBorders, onClick}) => {
+const Cells: React.SFC<Props> = ({xs, ys, verticalBorders, horizontalBorders, onClick, onHover}) => {
   return (
     <Columns>
       {xs.map((x, idx) => (
@@ -44,6 +50,9 @@ const Cells: React.SFC<Props> = ({xs, ys, verticalBorders, horizontalBorders, on
             <Cell
               key={y}
               onClick={() => onClick && onClick(x, y)}
+              onMouseOver={() => onHover && onHover({x, y})}
+              onMouseEnter={() => onHover && onHover({x, y})}
+              onMouseLeave={() => onHover && onHover(null)}
               style={{
                 borderBottom: horizontalBorders && horizontalBorders[(idy + 1) % horizontalBorders.length]
               }} />

--- a/src/Rectangle.tsx
+++ b/src/Rectangle.tsx
@@ -8,6 +8,7 @@ export interface Props {
   y: number;
   width: number | string;
   height: number | string;
+  onHover?: (hovering: boolean) => void;
 }
 
 const Container = styled.div`
@@ -24,7 +25,7 @@ export default class Rectangle extends React.Component<Props & React.HTMLAttribu
   context: PlotContext;
 
   render() {
-    const {x, y, height, width, style, ...remaining} = this.props;
+    const {x, y, height, width, style, onHover, ...remaining} = this.props;
 
     // invisible, don't render
     if (
@@ -55,6 +56,12 @@ export default class Rectangle extends React.Component<Props & React.HTMLAttribu
     };
 
     // provided styles override calculated styles.
-    return <Container {...remaining} style={{...layout, ...style}} />;
+    return <Container
+      onMouseEnter={() => onHover && onHover(true)}
+      onMouseOver={() => onHover && onHover(true)}
+      onMouseLeave={() => onHover && onHover(false)}
+      {...remaining}
+      style={{...layout, ...style}}
+    />;
   }
 }

--- a/src/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/__tests__/__snapshots__/index.test.tsx.snap
@@ -61,6 +61,9 @@ exports[`layout calculations clamped by bottom boundary 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -70,6 +73,9 @@ exports[`layout calculations clamped by bottom boundary 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -88,6 +94,9 @@ exports[`layout calculations clamped by bottom boundary 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -97,6 +106,9 @@ exports[`layout calculations clamped by bottom boundary 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -107,6 +119,9 @@ exports[`layout calculations clamped by bottom boundary 1`] = `
           </div>
           <div
             className="sc-htoDjs btzGSf"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
             style={
               Object {
                 "height": "50%",
@@ -184,6 +199,9 @@ exports[`layout calculations clamped by left boundary 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -193,6 +211,9 @@ exports[`layout calculations clamped by left boundary 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -211,6 +232,9 @@ exports[`layout calculations clamped by left boundary 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -220,6 +244,9 @@ exports[`layout calculations clamped by left boundary 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -230,6 +257,9 @@ exports[`layout calculations clamped by left boundary 1`] = `
           </div>
           <div
             className="sc-htoDjs btzGSf"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
             style={
               Object {
                 "height": "100%",
@@ -307,6 +337,9 @@ exports[`layout calculations clamped by right boundary 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -316,6 +349,9 @@ exports[`layout calculations clamped by right boundary 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -334,6 +370,9 @@ exports[`layout calculations clamped by right boundary 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -343,6 +382,9 @@ exports[`layout calculations clamped by right boundary 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -353,6 +395,9 @@ exports[`layout calculations clamped by right boundary 1`] = `
           </div>
           <div
             className="sc-htoDjs btzGSf"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
             style={
               Object {
                 "height": "100%",
@@ -430,6 +475,9 @@ exports[`layout calculations clamped by top boundary 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -439,6 +487,9 @@ exports[`layout calculations clamped by top boundary 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -457,6 +508,9 @@ exports[`layout calculations clamped by top boundary 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -466,6 +520,9 @@ exports[`layout calculations clamped by top boundary 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -476,6 +533,9 @@ exports[`layout calculations clamped by top boundary 1`] = `
           </div>
           <div
             className="sc-htoDjs btzGSf"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
             style={
               Object {
                 "height": "50%",
@@ -553,6 +613,9 @@ exports[`layout calculations too far above 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -562,6 +625,9 @@ exports[`layout calculations too far above 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -580,6 +646,9 @@ exports[`layout calculations too far above 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -589,6 +658,9 @@ exports[`layout calculations too far above 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -666,6 +738,9 @@ exports[`layout calculations too far below 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -675,6 +750,9 @@ exports[`layout calculations too far below 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -693,6 +771,9 @@ exports[`layout calculations too far below 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -702,6 +783,9 @@ exports[`layout calculations too far below 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -779,6 +863,9 @@ exports[`layout calculations too far left 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -788,6 +875,9 @@ exports[`layout calculations too far left 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -806,6 +896,9 @@ exports[`layout calculations too far left 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -815,6 +908,9 @@ exports[`layout calculations too far left 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -892,6 +988,9 @@ exports[`layout calculations too far right 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -901,6 +1000,9 @@ exports[`layout calculations too far right 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -919,6 +1021,9 @@ exports[`layout calculations too far right 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -928,6 +1033,9 @@ exports[`layout calculations too far right 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -1038,6 +1146,9 @@ exports[`static render 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -1047,6 +1158,9 @@ exports[`static render 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -1056,42 +1170,9 @@ exports[`static render 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
-                style={
-                  Object {
-                    "borderBottom": undefined,
-                  }
-                }
-              />
-            </div>
-            <div
-              className="sc-bZQynM loNdad"
-              style={
-                Object {
-                  "borderRight": undefined,
-                }
-              }
-            >
-              <div
-                className="sc-gzVnrw gfFhBZ"
-                onClick={[Function]}
-                style={
-                  Object {
-                    "borderBottom": undefined,
-                  }
-                }
-              />
-              <div
-                className="sc-gzVnrw gfFhBZ"
-                onClick={[Function]}
-                style={
-                  Object {
-                    "borderBottom": undefined,
-                  }
-                }
-              />
-              <div
-                className="sc-gzVnrw gfFhBZ"
-                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -1110,6 +1191,9 @@ exports[`static render 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -1119,6 +1203,9 @@ exports[`static render 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -1128,6 +1215,54 @@ exports[`static render 1`] = `
               <div
                 className="sc-gzVnrw gfFhBZ"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
+                style={
+                  Object {
+                    "borderBottom": undefined,
+                  }
+                }
+              />
+            </div>
+            <div
+              className="sc-bZQynM loNdad"
+              style={
+                Object {
+                  "borderRight": undefined,
+                }
+              }
+            >
+              <div
+                className="sc-gzVnrw gfFhBZ"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
+                style={
+                  Object {
+                    "borderBottom": undefined,
+                  }
+                }
+              />
+              <div
+                className="sc-gzVnrw gfFhBZ"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
+                style={
+                  Object {
+                    "borderBottom": undefined,
+                  }
+                }
+              />
+              <div
+                className="sc-gzVnrw gfFhBZ"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
                 style={
                   Object {
                     "borderBottom": undefined,
@@ -1138,6 +1273,9 @@ exports[`static render 1`] = `
           </div>
           <div
             className="sc-htoDjs btzGSf"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
             style={
               Object {
                 "height": "33.33333333333333%",
@@ -1149,6 +1287,9 @@ exports[`static render 1`] = `
           />
           <div
             className="sc-htoDjs btzGSf"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
             style={
               Object {
                 "height": "33.33333333333333%",
@@ -1160,6 +1301,9 @@ exports[`static render 1`] = `
           />
           <div
             className="sc-htoDjs btzGSf"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
             style={
               Object {
                 "height": "33.33333333333333%",
@@ -1171,6 +1315,9 @@ exports[`static render 1`] = `
           />
           <div
             className="sc-htoDjs btzGSf"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseOver={[Function]}
             style={
               Object {
                 "height": "33.33333333333333%",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ import CellPlot from './CellPlot';
 export default CellPlot;
 export {default as Rectangle} from './Rectangle';
 export {PlotConsumer, PlotConsumerProps} from './PlotConsumer';
+export {Coordinate} from './Cells';

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -4,7 +4,7 @@ import {action} from '@storybook/addon-actions';
 import {number} from '@storybook/addon-knobs';
 import styled from 'styled-components';
 
-import CellPlot, {Rectangle} from '../src';
+import CellPlot, {Rectangle, Coordinate} from '../src';
 
 const teal = '#58A9A3';
 const gold = '#CEB471';
@@ -47,22 +47,43 @@ function rangeToArray(r: [number, number]): number[] {
   return Array(r[1] - r[0] + 1).fill(0).map((_, idx) => idx + r[0]);
 }
 
-storiesOf('CellPlot', module)
-  .add('Grid', () => {
-    const xMin = number('xMin', 1, {range: true, min: 0, max: 5, step: 1});
-    const yMin = number('yMin', 1, {range: true, min: 0, max: 5, step: 1});
-    const xMax = number('xMax', 6, {range: true, min: 6, max: 20, step: 1});
-    const yMax = number('yMax', 6, {range: true, min: 6, max: 20, step: 1});
+interface DemoProps {
+  xMin: number;
+  yMin: number;
+  xMax: number;
+  yMax: number;
+}
 
+interface DemoState {
+  hovering: Coordinate | null;
+}
+
+class Demo extends React.Component<DemoProps, DemoState> {
+  constructor(props: DemoProps) {
+    super(props);
+
+    this.state = {
+      hovering: null
+    };
+  }
+
+  render() {
     return <Container>
       <CellPlot
         xLabels={[<XLabel>left</XLabel>, <XLabel>center</XLabel>, <XLabel>right</XLabel>]}
         yLabels={[<YLabel>top</YLabel>, <YLabel>center</YLabel>, <YLabel>bottom</YLabel>]}
-        xs={rangeToArray([xMin, xMax])}
-        ys={rangeToArray([yMin, yMax])}
+        xs={rangeToArray([this.props.xMin, this.props.xMax])}
+        ys={rangeToArray([this.props.yMin, this.props.yMax])}
         verticalBorders={['1px solid #555', '1px dotted #ccc']}
         horizontalBorders={['1px solid #555', '1px dotted #ccc']}
-        onClick={action('onClick')}>
+        onClick={action('onClick')}
+        onHover={(coord) => this.setState({hovering: coord})}>
+
+        {this.state.hovering &&
+          <Rectangle style={{zIndex: 1, pointerEvents: 'none'}} x={this.state.hovering.x} y={this.state.hovering.y} width={1} height={1}>
+            <Box style={{backgroundColor: 'yellow'}}></Box>
+          </Rectangle>
+        }
 
         <Rectangle x={5} y={3} width={2} height={2}>
           <Box style={{backgroundColor: teal}}>East</Box>
@@ -78,4 +99,15 @@ storiesOf('CellPlot', module)
         </Rectangle>
       </CellPlot>
     </Container>;
+  }
+}
+
+storiesOf('CellPlot', module)
+  .add('Grid', () => {
+    return <Demo
+      xMin={number('xMin', 1, {range: true, min: 0, max: 5, step: 1})}
+      yMin={number('yMin', 1, {range: true, min: 0, max: 5, step: 1})}
+      xMax={number('xMax', 6, {range: true, min: 6, max: 20, step: 1})}
+      yMax={number('yMax', 6, {range: true, min: 6, max: 20, step: 1})}
+    />;
   });

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -10,6 +10,7 @@ const teal = '#58A9A3';
 const gold = '#CEB471';
 const blue = '#53697D';
 const red = '#F7846B';
+const highlight = '#DDDD00';
 
 const Container = styled.div`
   width: 300px;
@@ -55,7 +56,11 @@ interface DemoProps {
 }
 
 interface DemoState {
-  hovering: Coordinate | null;
+  cellHover: Coordinate | null;
+  rectangleHoverEast: boolean;
+  rectangleHoverWest: boolean;
+  rectangleHoverNorth: boolean;
+  rectangleHoverSouth: boolean;
 }
 
 class Demo extends React.Component<DemoProps, DemoState> {
@@ -63,7 +68,11 @@ class Demo extends React.Component<DemoProps, DemoState> {
     super(props);
 
     this.state = {
-      hovering: null
+      cellHover: null,
+      rectangleHoverEast: false,
+      rectangleHoverWest: false,
+      rectangleHoverNorth: false,
+      rectangleHoverSouth: false
     };
   }
 
@@ -77,25 +86,33 @@ class Demo extends React.Component<DemoProps, DemoState> {
         verticalBorders={['1px solid #555', '1px dotted #ccc']}
         horizontalBorders={['1px solid #555', '1px dotted #ccc']}
         onClick={action('onClick')}
-        onHover={(coord) => this.setState({hovering: coord})}>
+        onHover={(coord) => this.setState({cellHover: coord})}>
 
-        {this.state.hovering &&
-          <Rectangle style={{zIndex: 1, pointerEvents: 'none'}} x={this.state.hovering.x} y={this.state.hovering.y} width={1} height={1}>
-            <Box style={{backgroundColor: 'yellow'}}></Box>
+        {this.state.cellHover &&
+          <Rectangle style={{zIndex: 1, pointerEvents: 'none'}} x={this.state.cellHover.x} y={this.state.cellHover.y} width={1} height={1}>
+            <Box style={{backgroundColor: highlight}}></Box>
           </Rectangle>
         }
 
-        <Rectangle x={5} y={3} width={2} height={2}>
-          <Box style={{backgroundColor: teal}}>East</Box>
+        <Rectangle x={5} y={3} width={2} height={2} onHover={(hovering: boolean) => this.setState({rectangleHoverEast: hovering})}>
+          <Box style={{backgroundColor: this.state.rectangleHoverEast ? highlight : teal}}>
+            East
+          </Box>
         </Rectangle>
-        <Rectangle x={3} y={5} width={2} height={2}>
-          <Box style={{backgroundColor: red}}>South</Box>
+        <Rectangle x={3} y={5} width={2} height={2} onHover={(hovering: boolean) => this.setState({rectangleHoverSouth: hovering})}>
+          <Box style={{backgroundColor: this.state.rectangleHoverSouth ? highlight : red}}>
+            South
+          </Box>
         </Rectangle>
-        <Rectangle x={1} y={3} width={2} height={2}>
-          <Box style={{backgroundColor: gold}}>West</Box>
+        <Rectangle x={1} y={3} width={2} height={2} onHover={(hovering: boolean) => this.setState({rectangleHoverWest: hovering})}>
+          <Box style={{backgroundColor: this.state.rectangleHoverWest ? highlight : gold}}>
+            West
+          </Box>
         </Rectangle>
-        <Rectangle x={3} y={1} width={2} height={2}>
-          <Box style={{backgroundColor: blue}}>North</Box>
+        <Rectangle x={3} y={1} width={2} height={2} onHover={(hovering: boolean) => this.setState({rectangleHoverNorth: hovering})}>
+          <Box style={{backgroundColor: this.state.rectangleHoverNorth ? highlight : blue}}>
+            North
+          </Box>
         </Rectangle>
       </CellPlot>
     </Container>;


### PR DESCRIPTION
`CellPlot` now supports an `onHover` event handler. The handler will get a coordinate of the cell currently hovered, or null if the cursor is no longer hovering over the plot. The handler will also get null if the cursor is over a `Rectangle` placed on the plot. This behavior can be changed with CSS `pointer-events: 'none'`.

The `Rectangle` component also supports an `onHover` event handler, but this handler only receives a boolean describing whether the rectangle is hovered or not.