### PR TITLE
yAt and xAt: floor instead of snap

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "react": "^15.0.0"
+    "react": ">15.0.0"
   },
   "jest": {
     "transform": {

--- a/src/CellPlot.tsx
+++ b/src/CellPlot.tsx
@@ -4,6 +4,7 @@ import Frame from './Frame';
 import Cells, {Coordinate} from './Cells';
 import {PlotContext, PlotContextProps} from './PlotContext';
 import {PlotConsumer, PlotConsumerProps} from './PlotConsumer';
+import {convertCoordinate} from './util';
 
 export interface Props {
   xLabels?: React.ReactNode[];
@@ -16,19 +17,6 @@ export interface Props {
 
   onClick?: (x: number, y: number) => void; // TODO: convert to Coordinate in 2.x release
   onHover?: (coordinate: Coordinate) => void;
-}
-
-function snap(value: number, interval: number): number {
-  const excess = value % interval;
-  if (excess >= 0.5 * interval) {
-    return value + interval - excess;
-  } else {
-    return value - excess;
-  }
-}
-
-function clamp(value: number, {min, max}: {min: number, max: number}): number {
-  return Math.max(Math.min(value, max), min);
 }
 
 /**
@@ -60,21 +48,11 @@ export default class CellPlot extends React.Component<Props> {
       gridYRange: gridYMax - gridYMin + gridYStep,
       yAt: (pxY: number): number => {
         const pxPerY = this.el.offsetHeight / gridYRange;
-        return Math.round(
-          clamp(
-            snap(pxY / pxPerY + gridYMin, gridYStep),
-            {min: gridYMin, max: gridYMax}
-          )
-        );
+        return convertCoordinate(pxY / pxPerY, {min: gridYMin, max: gridYMax, interval: gridYStep});
       },
       xAt: (pxX: number): number => {
         const pxPerX = this.el.offsetWidth / gridXRange;
-        return Math.round(
-          clamp(
-            snap(pxX / pxPerX + gridXMin, gridXStep),
-            {min: gridXMin, max: gridXMax}
-          )
-        );
+        return convertCoordinate(pxX / pxPerX, {min: gridXMin, max: gridXMax, interval: gridXStep});
       }
     };
   }

--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -1,0 +1,35 @@
+import {convertCoordinate} from '../util';
+
+describe('convertCoordinate', () => {
+  it('clamps to the boundaries', () => {
+    const opts = {
+      min: 3,
+      max: 5,
+      interval: 1
+    };
+
+    expect(convertCoordinate(-1, opts)).toBe(3); // out of bounds
+    expect(convertCoordinate(0, opts)).toBe(3); // on the edge
+    expect(convertCoordinate(1, opts)).toBe(4); // in the middle
+    expect(convertCoordinate(2, opts)).toBe(5); // on the edge
+    expect(convertCoordinate(3, opts)).toBe(5); // out of bounds
+  });
+
+  it('floors to intervals larger than 1', () => {
+    const opts = {
+      min: 0,
+      max: 30,
+      interval: 15
+    };
+
+    expect(convertCoordinate(0, opts)).toBe(0);
+    expect(convertCoordinate(1, opts)).toBe(0);
+    // ...
+    expect(convertCoordinate(14, opts)).toBe(0);
+    expect(convertCoordinate(15, opts)).toBe(15);
+    expect(convertCoordinate(16, opts)).toBe(15);
+    // ...
+    expect(convertCoordinate(29, opts)).toBe(15);
+    expect(convertCoordinate(30, opts)).toBe(30);
+  });
+});

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,19 @@
+function floor(value: number, interval: number): number {
+  const excess = value % interval;
+  return value - excess;
+}
+
+function clamp(value: number, {min, max}: {min: number, max: number}): number {
+  return Math.max(Math.min(value, max), min);
+}
+
+// relativeValue is expected to be converted to the plot's coordinate system, relative to its origin
+// (which may not necessarily be <0, 0>).
+export function convertCoordinate(relativeValue: number, opts: {min: number, max: number, interval: number}): number {
+  return Math.round(
+    clamp(
+      floor(relativeValue + opts.min, opts.interval),
+      {min: opts.min, max: opts.max}
+    )
+  );
+}


### PR DESCRIPTION
The `yAt` and `xAt` functions are provided to convert from screen to cell plot coordinates. The paradigm example is dragging and resizing.

Previously, these functions snapped up or down to the nearest cell's coordinate. This resulted in a subtly wrong effect where the function would return the coordinate for the *neighboring* cell.

Now, these functions floor down to the current cell's coordinate. This is more accurate. Any extra adjustments necessary to make dragging nice are the responsibility of the dragging logic.